### PR TITLE
feat: disable husky hooks in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Disabling the Husky hooks during CI release action.

fixes #9 