### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtimes (#56)

### DIFF
--- a/.github/workflows/purge-cdn.yml
+++ b/.github/workflows/purge-cdn.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "22.x"
 
       - name: Purge jsDelivr CDN cache
         run: node scripts/purge-cdn.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,18 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "22.x"
 
       - name: Cache Node.js modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## Summary

- Bump \ctions/checkout\ and \ctions/setup-node\ to \@v6\ (Node 24 action runtime)
- Bump \ctions/cache\ to \@v5\ in \elease.yml\
- Align workflow \
ode-version\ from \20.x\ to \22.x\ in both \elease.yml\ and \purge-cdn.yml\

Follow-up to #52 — v4 actions still ran on the deprecated Node 20 action runtime.

Closes #56

## Test plan

- [x] \
pm test\ (19/19 pass)
- [ ] PR workflow run: no Node.js 20 action-runtime deprecation warnings
- [ ] After merge: \Release\ and \Purge CDN\ succeed on next \main\ push