### PR TITLE
fix(chat): restore hover grow on inline GIFs and images

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -1,5 +1,5 @@
 #messagebuffer {
-  contain: layout style paint;
+  contain: layout style;
   content-visibility: auto;
 }
 #messagebuffer > div {
@@ -906,6 +906,43 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
   vertical-align: middle;
   margin: 2px 3px;
   border-radius: var(--btfw-radius);
+}
+
+/* Hover grow for inline chat GIFs/images (not channel emotes or avatars) */
+#messagebuffer > div:has(img.chat-picture) {
+  overflow: visible;
+}
+
+#messagebuffer img.chat-picture,
+#messagebuffer .chat-msg img:not(.channel-emote):not(.twemoji):not(.btfw-chat-avatar) {
+  position: relative;
+  z-index: 0;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  transform-origin: center center;
+}
+
+#messagebuffer img.chat-picture:hover,
+#messagebuffer .chat-msg img:not(.channel-emote):not(.twemoji):not(.btfw-chat-avatar):hover {
+  transform: scale(1.2);
+  z-index: 3;
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--btfw-color-bg) 55%, transparent 45%);
+}
+
+#messagebuffer > div:has(img.chat-picture:hover) {
+  z-index: 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #messagebuffer img.chat-picture,
+  #messagebuffer .chat-msg img:not(.channel-emote):not(.twemoji):not(.btfw-chat-avatar) {
+    transition: none;
+  }
+
+  #messagebuffer img.chat-picture:hover,
+  #messagebuffer .chat-msg img:not(.channel-emote):not(.twemoji):not(.btfw-chat-avatar):hover {
+    transform: none;
+    box-shadow: none;
+  }
 }
 
 /* Make chat emojis bigger (Twemoji images) */


### PR DESCRIPTION
## Summary
- Inline `.chat-picture` GIFs/images (Giphy, Tenor, generic chat images) scale to 1.2x on hover with a short transition and shadow lift
- Channel emotes, Twemoji, and avatars are excluded
- `#messagebuffer` uses `contain: layout style` (not `paint`) so scaled previews are not clipped; message rows with chat pictures allow overflow
- `prefers-reduced-motion: reduce` disables the effect

Fixes #75

## Test plan
- [x] `npm test` (31/31)
- [ ] Hover a Giphy/Tenor GIF in chat — modest grow, smooth restore on mouse leave
- [ ] Channel emotes do not scale on hover
- [ ] With reduced motion enabled in OS, no scale animation