### PR TITLE
fix(chat): restore GIF visibility with hover grow intact

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -1,5 +1,5 @@
 #messagebuffer {
-  contain: layout style;
+  contain: layout style paint;
   content-visibility: auto;
 }
 #messagebuffer > div {
@@ -18,8 +18,7 @@
   position: relative;
   min-height: 22px;
 }
-#messagebuffer > div:has(img.channel-emote) > span:last-child,
-#messagebuffer > div:has(img.chat-picture) > span:last-child {
+#messagebuffer > div:has(img.channel-emote):not(:has(img.chat-picture)) > span:last-child {
   line-height: 0.8rem;
 }
 .btfw-new-user-msg {
@@ -910,6 +909,8 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
 
 /* Hover grow for inline chat GIFs/images (not channel emotes or avatars) */
 #messagebuffer > div:has(img.chat-picture) {
+  content-visibility: visible;
+  contain-intrinsic-size: auto var(--btfw-emote-size, 130px);
   overflow: visible;
 }
 
@@ -917,6 +918,8 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
 #messagebuffer .chat-msg img:not(.channel-emote):not(.twemoji):not(.btfw-chat-avatar) {
   position: relative;
   z-index: 0;
+  min-width: 1px;
+  min-height: 1px;
   transition: transform 0.18s ease, box-shadow 0.18s ease;
   transform-origin: center center;
 }


### PR DESCRIPTION
Restore paint containment, stop 0.8rem line-height on chat-picture rows, and force content-visibility visible for GIF messages.