### PR TITLE
fix(build): bump tsconfig to ES2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2019",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2018", "DOM"],
+    "lib": ["ES2019", "DOM"],
     "allowJs": true,
     "checkJs": false,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Bump `tsconfig.json` `target`/`lib` from ES2018 to ES2019
- Fixes CI/Release typecheck failure: `flatMap` in `src/billtube-fw.ts` requires ES2019 lib

## Test plan
- [x] `npm run typecheck`
- [x] `npm run release:verify` (lint, typecheck, test, build)