### PR TITLE
feat(ci): simplify release pipeline (#165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,14 @@ jobs:
 
       - name: Check bundle sizes
         run: npm run check:bundles
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            dist/
+            css/
+            modules/user-release-notes.generated.js
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,27 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
       - main
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   release:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     env:
       HUSKY: 0
+      SKIP_BUILD: 1
 
     steps:
       - name: Checkout Repository
@@ -20,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -37,8 +47,15 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Release preflight
-        run: npm run release:verify
+      - name: Download CI build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify downloaded artifacts
+        run: npm run verify-dist
 
       - name: Run Semantic Release
         id: release
@@ -58,3 +75,7 @@ jobs:
       - name: Purge jsDelivr CDN cache
         if: steps.release.outputs.new_release_published == 'true'
         run: npm run purge-cdn
+
+      - name: Verify CDN deploy
+        if: steps.release.outputs.new_release_published == 'true'
+        run: npm run verify:cdn

--- a/BUILD.md
+++ b/BUILD.md
@@ -85,16 +85,74 @@ Boot always loads `dist/*.bundle.js` from the same origin/ref as `dist/billtube-
 
 ## Release pipeline
 
-On each semantic-release to `main`:
+Validation and publishing are split across two GitHub Actions workflows:
 
-1. Version bump in `package.json`
-2. `npm run build` — rebuild `dist/`
-3. `inject-cdn-version.js` — pin `channel_config_settings.js` to `@vX.Y.Z`
-4. Git commit includes `package.json`, `CHANGELOG.md`, `user-release-notes.json`, `modules/user-release-notes.generated.js`, `channel_config_settings.js`, `dist/billtube-fw.js`, all `dist/*.bundle.js`, and compiled `css/*.css`
-5. Git tag `vX.Y.Z` on that commit
-6. `npm run purge-cdn` — invalidate jsDelivr cache for fw, config, bundles, and CSS (release workflow; `purge-cdn.yml` on `main` when release commits touch `dist/` or `css/`)
+| Workflow | Trigger | Role |
+|----------|---------|------|
+| **CI** (`.github/workflows/ci.yml`) | Every push and PR | Lint, typecheck, test, build, bundle budgets; uploads `build-output` artifact |
+| **Release** (`.github/workflows/release.yml`) | After CI succeeds on `main` push | Reuses CI artifacts, runs semantic-release, purges CDN, verifies deploy |
 
-`dist/`, `css/`, and generated modules are **gitignored on `main`** between releases; only release tags carry built assets for jsDelivr.
+PRs only run CI. Merges to `main` run CI once; Release waits for that run and does **not** repeat lint/test/build.
+
+### Build outputs (what ships)
+
+| Output | Source | On jsDelivr |
+|--------|--------|-------------|
+| `dist/billtube-fw.js` | `src/billtube-fw.ts` via esbuild | Loader; derives `BASE` for all assets |
+| `dist/*.bundle.js` (6 files) | `modules/` via esbuild | Feature code |
+| `css/*.css` (8 files) | `scss/` via dart-sass | Theme styles |
+| `channel_config_settings.js` | Hand-edited + release pin | CyTube channel snippet |
+| `modules/user-release-notes.generated.js` | `user-release-notes.json` at build | Bundled into admin (release commit) |
+
+`dist/`, `css/`, and generated modules are **gitignored on `main`** between releases. Release tags include built assets for jsDelivr (`@vX.Y.Z`).
+
+### Release steps (automated)
+
+On each releasable push to `main` (after CI passes):
+
+1. **CI** — `npm run lint:ci`, `typecheck`, `test`, `build`, `check:bundles`; upload `dist/`, `css/`, `user-release-notes.generated.js`
+2. **Release** — download artifacts (`SKIP_BUILD=1`), `verify-dist`
+3. **semantic-release** — version bump, changelog, `prepare:release` (skip build, run `inject-cdn-version.js`)
+4. **Git commit** — `package.json`, `CHANGELOG.md`, pinned `channel_config_settings.js`, all `dist/*.js`, all `css/*.css`
+5. **Git tag** — `vX.Y.Z`
+6. **Purge** — `npm run purge-cdn` invalidates jsDelivr cache for every shipped path
+7. **Verify** — `npm run verify:cdn` fetches each asset from `@vX.Y.Z`, checks HTTP 200, content markers, and CDN pin in channel config. Release fails if verification fails.
+
+Local preflight (same checks as CI, without CDN verify):
+
+```bash
+npm run release:verify
+```
+
+### CDN version injection
+
+`scripts/inject-cdn-version.js` runs during `prepare:release` **after** semantic-release bumps `package.json` version:
+
+- Replaces `gh/intentionallyIncomplete/cytube-custom-overlay-theme@*` refs in `channel_config_settings.js` with `@vX.Y.Z`
+- Also supports `@__VERSION__` placeholder if present
+
+The pinned `CDN_BASE` in the release commit must match the git tag viewers load from jsDelivr.
+
+### Purge timing
+
+| When | What runs |
+|------|-----------|
+| New release published | `release.yml` → `purge-cdn` then `verify:cdn` |
+| Push to `main` touches `dist/` or `css/` | `.github/workflows/purge-cdn.yml` (e.g. release commit) |
+
+Purge uses `https://purge.jsdelivr.net/gh/...` for each path in `lib/cdn-deploy.js` → `CDN_ASSET_PATHS`.
+
+### Rollback
+
+jsDelivr git refs are immutable per tag. To roll back viewers:
+
+1. Open the last good tag on GitHub (e.g. `v1.21.2`)
+2. Copy `channel_config_settings.js` from that tag (or set `CDN_BASE` to `@v1.21.2`)
+3. Paste into CyTube → Channel Settings → Javascript → Save JS
+
+No purge is required when pinning an **older** tag — that ref still exists on GitHub. To ship a forward fix, merge to `main` and let semantic-release cut a new patch.
+
+If a bad release tag must be abandoned, revert the release commit on `main` and cut a new release; channels stay on the previous `@v` pin until updated.
 
 ### Commit types and version bumps
 
@@ -129,6 +187,8 @@ BillTube3-slim/
     ├── check-bundle-sizes.js
     ├── bundle-size-budget.json
     ├── inject-cdn-version.js
+    ├── prepare-release.js   # semantic-release prepare (build or reuse CI artifacts)
+    ├── verify-cdn-deploy.js # post-purge jsDelivr smoke test
     └── purge-cdn.js
 ```
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -27,6 +27,8 @@ Do not add new `.eslintrc.*`, `.stylelintrc.*`, or inline `lint-staged` blocks i
 
 CI sets `HUSKY=0` during `npm ci` so install skips hook wiring; the workflow runs the same checks explicitly (`npm run lint:ci`, `typecheck`, `test`, `build`, `check:bundles`).
 
+Release workflow (`.github/workflows/release.yml`) runs after CI on `main`, downloads the `build-output` artifact, and sets `SKIP_BUILD=1` so semantic-release does not rebuild. Post-publish: `purge-cdn` then `verify:cdn`. See [BUILD.md](../BUILD.md#release-pipeline).
+
 ## Build outputs
 
 - Generated `dist/`, `css/`, and `modules/user-release-notes.generated.js` are gitignored on `main`.

--- a/lib/cdn-deploy.js
+++ b/lib/cdn-deploy.js
@@ -1,0 +1,75 @@
+/** @typedef {{ ok: true } | { ok: false, reason: string }} VerifyResult */
+
+export const CDN_REPO = "intentionallyIncomplete/cytube-custom-overlay-theme";
+
+/** Paths shipped on jsDelivr for each release tag. */
+export const CDN_ASSET_PATHS = [
+  "channel_config_settings.js",
+  "dist/billtube-fw.js",
+  "dist/core.bundle.js",
+  "dist/chat.bundle.js",
+  "dist/player.bundle.js",
+  "dist/playlist.bundle.js",
+  "dist/admin.bundle.js",
+  "dist/features.bundle.js",
+  "css/tokens.css",
+  "css/base.css",
+  "css/navbar.css",
+  "css/chat.css",
+  "css/overlays.css",
+  "css/player.css",
+  "css/mobile.css",
+  "css/boot-overlay.css",
+];
+
+/**
+ * @param {string} repo
+ * @param {string} tag e.g. v1.2.3 (no leading @)
+ * @param {string} filePath
+ */
+export function buildCdnUrl(repo, tag, filePath) {
+  const normalizedTag = tag.replace(/^@/, "");
+  return `https://cdn.jsdelivr.net/gh/${repo}@${normalizedTag}/${filePath}`;
+}
+
+/**
+ * @param {string} content
+ * @param {string} tag e.g. v1.2.3
+ * @returns {VerifyResult}
+ */
+export function verifyChannelConfigPin(content, tag) {
+  const normalizedTag = tag.replace(/^@/, "");
+  const needle = `@${normalizedTag}`;
+  if (!content.includes(needle)) {
+    return { ok: false, reason: `channel_config_settings.js missing CDN pin ${needle}` };
+  }
+  return { ok: true };
+}
+
+/**
+ * @param {string} filePath
+ * @param {string} content
+ * @returns {VerifyResult}
+ */
+export function verifyAssetContent(filePath, content) {
+  if (!content || content.length < 50) {
+    return { ok: false, reason: `${filePath} empty or too small` };
+  }
+
+  if (filePath === "dist/core.bundle.js" && !/util:motion/.test(content)) {
+    return { ok: false, reason: "core.bundle.js missing util:motion marker" };
+  }
+
+  if (filePath === "dist/billtube-fw.js" && !/BTFW/.test(content)) {
+    return { ok: false, reason: "dist/billtube-fw.js missing BTFW marker" };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * @param {number} ms
+ */
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "check:bundles": "node scripts/check-bundle-sizes.js",
     "inject-cdn": "node scripts/inject-cdn-version.js",
     "purge-cdn": "node scripts/purge-cdn.js",
+    "verify:cdn": "node scripts/verify-cdn-deploy.js",
+    "prepare:release": "node scripts/prepare-release.js",
     "dev": "node scripts/dev.js",
     "watch": "node scripts/dev.js",
     "dev:server": "node scripts/dev-server.js",
@@ -122,7 +124,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "npm run build && node scripts/inject-cdn-version.js"
+          "prepareCmd": "node scripts/prepare-release.js"
         }
       ],
       [

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import { execSync } from "child_process";
+
+const skipBuild = process.env.SKIP_BUILD === "1" || process.env.SKIP_BUILD === "true";
+
+if (skipBuild) {
+  console.log("SKIP_BUILD=1 — reusing CI build artifacts");
+  execSync("npm run verify-dist", { stdio: "inherit" });
+} else {
+  execSync("npm run build", { stdio: "inherit" });
+}
+
+execSync("node scripts/inject-cdn-version.js", { stdio: "inherit" });

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -1,32 +1,14 @@
 import { readFileSync } from "fs";
 
-const REPO = "intentionallyIncomplete/cytube-custom-overlay-theme";
+import { CDN_ASSET_PATHS, CDN_REPO } from "../lib/cdn-deploy.js";
+
 const version = JSON.parse(readFileSync("package.json", "utf8")).version;
 const tag = `v${version}`;
 
-const FILES = [
-  "channel_config_settings.js",
-  "dist/billtube-fw.js",
-  "dist/core.bundle.js",
-  "dist/chat.bundle.js",
-  "dist/player.bundle.js",
-  "dist/playlist.bundle.js",
-  "dist/admin.bundle.js",
-  "dist/features.bundle.js",
-  "css/tokens.css",
-  "css/base.css",
-  "css/navbar.css",
-  "css/chat.css",
-  "css/overlays.css",
-  "css/player.css",
-  "css/mobile.css",
-  "css/boot-overlay.css"
-];
-
 let failed = 0;
 
-for (const file of FILES) {
-  const url = `https://purge.jsdelivr.net/gh/${REPO}@${tag}/${file}`;
+for (const file of CDN_ASSET_PATHS) {
+  const url = `https://purge.jsdelivr.net/gh/${CDN_REPO}@${tag}/${file}`;
   const res = await fetch(url);
   const ok = res.ok;
   console.log(`${ok ? "✓" : "✗"} purge ${tag}/${file} (${res.status})`);

--- a/scripts/verify-cdn-deploy.js
+++ b/scripts/verify-cdn-deploy.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import {
+  buildCdnUrl,
+  CDN_ASSET_PATHS,
+  CDN_REPO,
+  sleep,
+  verifyAssetContent,
+  verifyChannelConfigPin,
+} from "../lib/cdn-deploy.js";
+
+const DEFAULT_ATTEMPTS = 8;
+const DEFAULT_DELAY_MS = 5000;
+
+/**
+ * @param {string} url
+ * @param {{ attempts?: number, delayMs?: number }} [options]
+ */
+export async function fetchCdnAsset(url, options = {}) {
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
+  let lastStatus = 0;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const res = await fetch(url, { redirect: "follow" });
+    lastStatus = res.status;
+    if (res.ok) {
+      return { ok: true, status: res.status, body: await res.text() };
+    }
+    if (attempt < attempts) {
+      console.log(`  retry ${attempt}/${attempts - 1} (${res.status}) ${url}`);
+      await sleep(delayMs);
+    }
+  }
+
+  return { ok: false, status: lastStatus, body: "" };
+}
+
+/**
+ * @param {string} tag
+ * @param {{ repo?: string, attempts?: number, delayMs?: number }} [options]
+ */
+export async function verifyCdnDeploy(tag, options = {}) {
+  const repo = options.repo ?? CDN_REPO;
+  const attempts = options.attempts;
+  const delayMs = options.delayMs;
+  const failures = [];
+
+  console.log(`Verifying jsDelivr deploy for ${repo}@${tag.replace(/^@/, "")}...\n`);
+
+  for (const filePath of CDN_ASSET_PATHS) {
+    const url = buildCdnUrl(repo, tag, filePath);
+    const fetched = await fetchCdnAsset(url, { attempts, delayMs });
+
+    if (!fetched.ok) {
+      failures.push(`${filePath}: HTTP ${fetched.status}`);
+      console.log(`✗ ${filePath} (${fetched.status})`);
+      continue;
+    }
+
+    const contentCheck = verifyAssetContent(filePath, fetched.body);
+    if (!contentCheck.ok) {
+      failures.push(`${filePath}: ${contentCheck.reason}`);
+      console.log(`✗ ${filePath} — ${contentCheck.reason}`);
+      continue;
+    }
+
+    if (filePath === "channel_config_settings.js") {
+      const pinCheck = verifyChannelConfigPin(fetched.body, tag);
+      if (!pinCheck.ok) {
+        failures.push(pinCheck.reason);
+        console.log(`✗ ${filePath} — ${pinCheck.reason}`);
+        continue;
+      }
+    }
+
+    console.log(`✓ ${filePath}`);
+  }
+
+  return { ok: failures.length === 0, failures };
+}
+
+function readTagFromArgs() {
+  const tagArg = process.argv.find((arg) => arg.startsWith("--tag="));
+  if (tagArg) {
+    return tagArg.slice("--tag=".length).replace(/^@/, "");
+  }
+  const version = JSON.parse(readFileSync("package.json", "utf8")).version;
+  return `v${version}`;
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  const tag = readTagFromArgs();
+  const { ok, failures } = await verifyCdnDeploy(tag);
+
+  if (!ok) {
+    console.error("\nCDN deploy verification failed:");
+    failures.forEach((line) => console.error(`  - ${line}`));
+    process.exit(1);
+  }
+
+  console.log("\n✓ CDN deploy verification passed");
+}

--- a/test/cdn-deploy.test.js
+++ b/test/cdn-deploy.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildCdnUrl,
+  verifyAssetContent,
+  verifyChannelConfigPin,
+} from "../lib/cdn-deploy.js";
+
+describe("cdn-deploy", () => {
+  it("buildCdnUrl uses gh ref path", () => {
+    assert.equal(
+      buildCdnUrl("owner/repo", "v1.2.3", "dist/billtube-fw.js"),
+      "https://cdn.jsdelivr.net/gh/owner/repo@v1.2.3/dist/billtube-fw.js"
+    );
+  });
+
+  it("verifyChannelConfigPin accepts pinned CDN_BASE", () => {
+    const content = 'const CDN_BASE = "https://cdn.jsdelivr.net/gh/owner/repo@v1.2.3";';
+    assert.equal(verifyChannelConfigPin(content, "v1.2.3").ok, true);
+  });
+
+  it("verifyChannelConfigPin rejects wrong tag", () => {
+    const content = 'const CDN_BASE = "https://cdn.jsdelivr.net/gh/owner/repo@v1.0.0";';
+    assert.equal(verifyChannelConfigPin(content, "v1.2.3").ok, false);
+  });
+
+  it("verifyAssetContent requires util:motion in core bundle", () => {
+    const core = "x".repeat(50) + "BTFW.define('util:motion'";
+    assert.equal(verifyAssetContent("dist/core.bundle.js", core).ok, true);
+    assert.equal(verifyAssetContent("dist/core.bundle.js", "x".repeat(50)).ok, false);
+  });
+
+  it("verifyAssetContent requires BTFW marker in loader", () => {
+    const loader = "x".repeat(50) + "window.BTFW = {}";
+    assert.equal(verifyAssetContent("dist/billtube-fw.js", loader).ok, true);
+    assert.equal(verifyAssetContent("dist/billtube-fw.js", "x".repeat(10)).ok, false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements epic [#165](https://github.com/intentionallyIncomplete/cytube-custom-overlay-theme/issues/165):

- **#167** — CI uploads \uild-output\ artifacts; Release runs after CI on \main\, downloads artifacts, sets \SKIP_BUILD=1\, and skips \
elease:verify\ rebuild
- **#166** — After purge, \
pm run verify:cdn\ fetches every shipped asset from jsDelivr \@vX.Y.Z\, checks HTTP 200, content markers, and CDN pin in channel config (with retries)
- **#168** — BUILD.md documents build outputs, CDN injection, purge timing, rollback, and CI/Release split

## Architecture

\\\
push main → CI (lint/test/build) → upload artifacts
                ↓
         Release (workflow_run)
           → download artifacts
           → semantic-release (prepare:release, inject CDN pin)
           → purge-cdn
           → verify:cdn (fail release if CDN not live)
\\\

## Test plan

- [x] \
pm run release:verify\ (111 tests including \cdn-deploy\)
- [x] Merge and confirm Release workflow triggers after CI on \main\
- [x] On next release: confirm purge + verify:cdn pass in Actions logs

Closes #166, #167, #168. Part of #165.