### PR TITLE
feat(e2e): Playwright smoke suite for overlay (#170)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,6 +9,17 @@ Stable Playwright target for overlay regression tests ([#171](https://github.com
 | Fixture (default) | `npm run test:e2e` | Static CyTube-like page + local asset server |
 | Full stack (local) | `E2E_BASE_URL=http://localhost:8080/r/<channel> npm run test:e2e` | CyTube Docker from `sync` + BillTube dev server |
 
+## Smoke suite ([#170](https://github.com/intentionallyIncomplete/cytube-custom-overlay-theme/issues/170))
+
+`e2e/smoke/overlay-smoke.spec.js` covers:
+
+- App boot (grid ready, boot overlay dismissed)
+- Overlay load (video stage, video overlay, chat column)
+- Chat / player rendering (chat chrome, message buffer, player shell)
+- Failure path (core bundle abort → boot error status)
+
+`e2e/helpers/boot.js` shared `gotoFixtureAndBoot()` waits on `data-testid` hooks — no console-string coupling.
+
 ## Fixture server (CI + local default)
 
 1. `npm run build`

--- a/e2e/fixture/channel.html
+++ b/e2e/fixture/channel.html
@@ -51,7 +51,7 @@
           </div>
         </div>
         <div id="main" class="row">
-          <div id="chatwrap" class="col-chat">
+          <div id="chatwrap" class="col-chat" data-testid="cytube-chatwrap">
             <div id="chatheader">
               <span id="usercount">1</span>
             </div>
@@ -66,7 +66,7 @@
               <span id="currenttitle">Nothing Playing</span>
             </p>
             <div class="embed-responsive embed-responsive-16by9">
-              <div id="ytapiplayer" class="embed-responsive-item"></div>
+              <div id="ytapiplayer" class="embed-responsive-item" data-testid="cytube-player"></div>
             </div>
           </div>
         </div>

--- a/e2e/helpers/boot.js
+++ b/e2e/helpers/boot.js
@@ -1,0 +1,10 @@
+import { expect } from "@playwright/test";
+
+export const FIXTURE_PATH = process.env.E2E_FIXTURE_PATH || "/e2e/fixture/channel.html";
+
+/** Navigate to the fixture and wait until BillTube layout is ready. */
+export async function gotoFixtureAndBoot(page) {
+  await page.goto(FIXTURE_PATH, { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("btfw-grid")).toBeVisible({ timeout: 45_000 });
+  await expect(page.getByTestId("btfw-boot-overlay")).toHaveCount(0);
+}

--- a/e2e/smoke/fixture-boot.spec.js
+++ b/e2e/smoke/fixture-boot.spec.js
@@ -1,27 +1,15 @@
 import { test, expect } from "@playwright/test";
-
-const fixturePath = process.env.E2E_FIXTURE_PATH || "/e2e/fixture/channel.html";
+import { gotoFixtureAndBoot } from "../helpers/boot.js";
 
 test.describe.configure({ mode: "parallel" });
 
+/** Fixture target sanity from #171 — full smoke coverage lives in overlay-smoke.spec.js (#170). */
 test.describe("E2E fixture target", () => {
   test("fixture page boots BillTube overlay", async ({ page }) => {
-    await page.goto(fixturePath, { waitUntil: "domcontentloaded" });
+    await gotoFixtureAndBoot(page);
 
-    await expect(page.getByTestId("btfw-grid")).toBeVisible({ timeout: 45_000 });
-    await expect(page.getByTestId("btfw-boot-overlay")).toHaveCount(0);
+    await expect(page.getByTestId("btfw-grid")).toBeVisible();
     await expect(page.getByTestId("cytube-messagebuffer")).toBeVisible();
     await expect(page.getByTestId("cytube-videowrap")).toBeVisible();
-  });
-
-  test("fixture reports boot failure when a bundle fails to load", async ({ page }) => {
-    await page.route("**/dist/core.bundle.js*", (route) => route.abort());
-    await page.goto(fixturePath, { waitUntil: "domcontentloaded" });
-
-    const bootStatus = page.getByRole("status");
-    await expect(bootStatus).toBeVisible({ timeout: 30_000 });
-    await expect(bootStatus).toHaveAttribute("data-state", "error");
-    await expect(bootStatus).toContainText(/went wrong|refresh to retry/i);
-    await expect(page.getByTestId("btfw-grid")).toHaveCount(0);
   });
 });

--- a/e2e/smoke/overlay-smoke.spec.js
+++ b/e2e/smoke/overlay-smoke.spec.js
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { FIXTURE_PATH, gotoFixtureAndBoot } from "../helpers/boot.js";
+
+test.describe.configure({ mode: "parallel" });
+
+test.describe("smoke: app boot", () => {
+  test("loads framework and dismisses boot overlay", async ({ page }) => {
+    await gotoFixtureAndBoot(page);
+
+    await expect(page.getByTestId("btfw-grid")).toBeVisible();
+    await expect(page.getByTestId("btfw-boot-overlay")).toHaveCount(0);
+  });
+});
+
+test.describe("smoke: overlay load", () => {
+  test("mounts layout grid, video stage, and video overlay chrome", async ({ page }) => {
+    await gotoFixtureAndBoot(page);
+
+    await expect(page.getByTestId("btfw-video-stage")).toBeVisible();
+    await expect(page.getByTestId("btfw-video-overlay")).toBeVisible();
+    await expect(page.getByTestId("btfw-chatcol")).toBeVisible();
+  });
+});
+
+test.describe("smoke: chat and player rendering", () => {
+  test("renders chat chrome and player shell", async ({ page }) => {
+    await gotoFixtureAndBoot(page);
+
+    await expect(page.getByTestId("btfw-chat-topbar")).toBeVisible();
+    await expect(page.getByTestId("btfw-chat-bottombar")).toBeVisible();
+    await expect(page.getByTestId("cytube-messagebuffer")).toBeVisible();
+    await expect(page.getByLabel("Chat message")).toBeVisible();
+
+    await expect(page.getByTestId("cytube-videowrap")).toBeVisible();
+    await expect(page.getByTestId("cytube-player")).toBeVisible();
+  });
+});
+
+test.describe("smoke: failure path", () => {
+  test("surfaces boot error when a required bundle fails", async ({ page }) => {
+    await page.route("**/dist/core.bundle.js*", (route) => route.abort());
+    await page.goto(FIXTURE_PATH, { waitUntil: "domcontentloaded" });
+
+    const bootStatus = page.getByRole("status");
+    await expect(bootStatus).toBeVisible({ timeout: 30_000 });
+    await expect(bootStatus).toHaveAttribute("data-state", "error");
+    await expect(bootStatus).toContainText(/went wrong|refresh to retry/i);
+    await expect(page.getByTestId("btfw-grid")).toHaveCount(0);
+  });
+});

--- a/src/modules/feature-chat.js
+++ b/src/modules/feature-chat.js
@@ -859,8 +859,11 @@ const scheduleNormalizeChatActions = (() => {
     if (!top) {
       top = document.createElement("div");
       top.className = "btfw-chat-topbar";
+      top.setAttribute("data-testid", "btfw-chat-topbar");
       top.innerHTML = chatTpl.chatTopbarHtml();
       cw.prepend(top);
+    } else if (!top.getAttribute("data-testid")) {
+      top.setAttribute("data-testid", "btfw-chat-topbar");
     }
 
     let left = top.querySelector(".btfw-chat-topbar-left");
@@ -891,7 +894,10 @@ const scheduleNormalizeChatActions = (() => {
     if (!bottom) {
       bottom = document.createElement("div");
       bottom.className = "btfw-chat-bottombar";
+      bottom.setAttribute("data-testid", "btfw-chat-bottombar");
       cw.appendChild(bottom);
+    } else if (!bottom.getAttribute("data-testid")) {
+      bottom.setAttribute("data-testid", "btfw-chat-bottombar");
     }
 
     const legacyComposer = bottom.querySelector(".btfw-chat-composer");

--- a/src/modules/feature-layout.js
+++ b/src/modules/feature-layout.js
@@ -538,6 +538,9 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:themeMode"], async (
       stage = document.createElement("div");
       stage.id = "btfw-video-stage";
       stage.className = "btfw-video-stage";
+      stage.setAttribute("data-testid", "btfw-video-stage");
+    } else if (!stage.getAttribute("data-testid")) {
+      stage.setAttribute("data-testid", "btfw-video-stage");
     }
     if (stage.parentElement !== left) {
       left.insertBefore(stage, left.firstChild);
@@ -564,6 +567,7 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:themeMode"], async (
 
       const right=document.createElement("aside");
       right.id="btfw-chatcol";
+      right.setAttribute("data-testid", "btfw-chatcol");
 
       if(v) left.appendChild(v);
       if(q) left.appendChild(q);
@@ -584,10 +588,16 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:themeMode"], async (
     } else {
       const left=document.getElementById("btfw-leftpad");
       const right=document.getElementById("btfw-chatcol");
+      if (right && !right.getAttribute("data-testid")) {
+        right.setAttribute("data-testid", "btfw-chatcol");
+      }
       const v=document.getElementById("videowrap");
       const c=document.getElementById("chatwrap");
       const q=document.getElementById("playlistrow")||document.getElementById("playlistwrap")||document.getElementById("queuecontainer");
       const grid=document.getElementById("btfw-grid");
+      if (grid && !grid.getAttribute("data-testid")) {
+        grid.setAttribute("data-testid", "btfw-grid");
+      }
 
       ensureNavHost(grid);
 

--- a/src/modules/feature-video-overlay.js
+++ b/src/modules/feature-video-overlay.js
@@ -293,8 +293,12 @@ BTFW.define("feature:videoOverlay", [], async () => {
     if (!overlay) {
       overlay = document.createElement("div");
       overlay.id = "btfw-video-overlay";
+      overlay.setAttribute("data-testid", "btfw-video-overlay");
     }
     overlay.classList.add("btfw-video-overlay");
+    if (!overlay.getAttribute("data-testid")) {
+      overlay.setAttribute("data-testid", "btfw-video-overlay");
+    }
     mountOverlayToolbar(overlay);
 
     let bar = overlay.querySelector("#btfw-vo-bar");


### PR DESCRIPTION
## Summary
- Expands E2E smoke coverage for app boot, overlay load, chat/player rendering, and a bundle failure path
- Adds \data-testid\ hooks on grid/chat/video chrome and a shared \gotoFixtureAndBoot\ helper
- Keeps fixture-target sanity from #171; full AC lives in \overlay-smoke.spec.js\

Closes #170

## Test plan
- [x] \
pm run build\
- [x] \
pm run test:e2e\ (5/5 pass)
- [x] CI \e2e\ job green on PR