### PR TITLE
ci(release): gate releases on E2E success (#172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,11 @@ jobs:
             test-results/
           retention-days: 7
           if-no-files-found: ignore
+
+  # Single green signal for Release (#172): lint/typecheck/unit/build + Playwright.
+  ci-gate:
+    runs-on: ubuntu-latest
+    needs: [verify, e2e]
+    steps:
+      - name: CI gate passed
+        run: echo "verify and e2e succeeded"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,38 @@ jobs:
       SKIP_BUILD: 1
 
     steps:
+      - name: Assert CI gate jobs succeeded
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const required = ["verify", "e2e", "ci-gate"];
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100
+              }
+            );
+            const failures = [];
+            for (const name of required) {
+              const job = jobs.find((j) => j.name === name);
+              if (!job) {
+                failures.push(`${name}: missing`);
+                continue;
+              }
+              if (job.conclusion !== "success") {
+                failures.push(`${name}: ${job.conclusion || job.status}`);
+              }
+            }
+            if (failures.length) {
+              core.setFailed(
+                `Release blocked — required CI jobs did not succeed:\n${failures.join("\n")}`
+              );
+            }
+
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/BUILD.md
+++ b/BUILD.md
@@ -28,7 +28,7 @@ BillTube bundles modules for production (6 HTTP requests instead of 33+) and ser
 ```bash
 npm install
 npm run build          # esbuild: scss → css/, src + modules → dist/billtube-fw.js + dist/*.bundle.js
-npm run release:verify # lint, typecheck, test, build
+npm run release:verify # lint, typecheck, test, build, Playwright E2E
 npm run verify-dist    # fail if bundles missing
 ```
 
@@ -88,10 +88,10 @@ Validation and publishing are split across two GitHub Actions workflows:
 
 | Workflow | Trigger | Role |
 |----------|---------|------|
-| **CI** (`.github/workflows/ci.yml`) | Every push and PR | Lint, typecheck, test, build, bundle budgets; uploads `build-output` artifact |
-| **Release** (`.github/workflows/release.yml`) | After CI succeeds on `main` push | Reuses CI artifacts, runs semantic-release, purges CDN, verifies deploy |
+| **CI** (`.github/workflows/ci.yml`) | Every push and PR | Lint, typecheck, unit tests, build, Playwright E2E (`ci-gate`); uploads `build-output` artifact |
+| **Release** (`.github/workflows/release.yml`) | After CI succeeds on `main` push | Asserts `verify` + `e2e` + `ci-gate`, reuses CI artifacts, runs semantic-release, purges CDN, verifies deploy |
 
-PRs only run CI. Merges to `main` run CI once; Release waits for that run and does **not** repeat lint/test/build.
+PRs only run CI. Merges to `main` run CI once; Release waits for that run and does **not** proceed unless lint, typecheck, unit tests, build, and Playwright smoke tests all succeed.
 
 ### Build outputs (what ships)
 
@@ -109,17 +109,18 @@ PRs only run CI. Merges to `main` run CI once; Release waits for that run and do
 
 On each releasable push to `main` (after CI passes):
 
-1. **CI** — `npm run lint:ci`, `typecheck`, `test`, `build`; upload `dist/`, `css/`, `user-release-notes.generated.js`
-2. **Release** — download artifacts (`SKIP_BUILD=1`), `verify-dist`
+1. **CI** — `npm run lint:ci`, `typecheck`, `test`, `build`, Playwright E2E; upload `dist/`, `css/`, `user-release-notes.generated.js`
+2. **Release** — assert CI jobs (`verify`, `e2e`, `ci-gate`), download artifacts (`SKIP_BUILD=1`), `verify-dist`
 3. **semantic-release** — version bump, changelog, `prepare:release` (skip build, run `inject-cdn-version.js`)
 4. **Git commit** — `package.json`, `CHANGELOG.md`, pinned `channel_config_settings.js`, all `dist/*.js`, all `css/*.css`
 5. **Git tag** — `vX.Y.Z`
 6. **Purge** — `npm run purge-cdn` invalidates jsDelivr cache for every shipped path
 7. **Verify** — `npm run verify:cdn` fetches each asset from `@vX.Y.Z`, checks HTTP 200, content markers, and CDN pin in channel config. Release fails if verification fails.
 
-Local preflight (same checks as CI, without CDN verify):
+Local preflight (same checks as CI verify + E2E, without CDN verify):
 
 ```bash
+npm run test:e2e:install   # once, if Chromium is missing
 npm run release:verify
 ```
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -25,9 +25,9 @@ Do not add new `.eslintrc.*`, `.stylelintrc.*`, or inline `lint-staged` blocks i
 - **pre-commit** — `lint-staged`
 - **commit-msg** — `commitlint`
 
-CI sets `HUSKY=0` during `npm ci` so install skips hook wiring; the workflow runs the same checks explicitly (`npm run lint:ci`, `typecheck`, `test`, `build`).
+CI sets `HUSKY=0` during `npm ci` so install skips hook wiring; the workflow runs the same checks explicitly (`npm run lint:ci`, `typecheck`, `test`, `build`, Playwright E2E).
 
-Release workflow (`.github/workflows/release.yml`) runs after CI on `main`, downloads the `build-output` artifact, and sets `SKIP_BUILD=1` so semantic-release does not rebuild. Post-publish: `purge-cdn` then `verify:cdn`. See [BUILD.md](../BUILD.md#release-pipeline).
+Release workflow (`.github/workflows/release.yml`) runs after CI on `main` only when `verify`, `e2e`, and `ci-gate` succeed; it downloads the `build-output` artifact and sets `SKIP_BUILD=1` so semantic-release does not rebuild. Post-publish: `purge-cdn` then `verify:cdn`. See [BUILD.md](../BUILD.md#release-pipeline).
 
 ## Build outputs
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "e2e:server": "node scripts/e2e-server.js",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install --with-deps chromium",
-    "release:verify": "npm run lint:ci && npm run typecheck && npm test && npm run build",
+    "release:verify": "npm run lint:ci && npm run typecheck && npm test && npm run build && npm run test:e2e",
     "release": "semantic-release",
     "release:dry-run": "semantic-release --dry-run"
   },


### PR DESCRIPTION
## Summary
- Adds CI \ci-gate\ job that requires both \erify\ and \e2e\
- Release workflow asserts \erify\, \e2e\, and \ci-gate\ succeeded before semantic-release
- \elease:verify\ now includes Playwright smoke tests
- Docs updated for the E2E release gate

Closes #172

Part of epic #169

## Test plan
- [ ] CI runs \erify\ → \e2e\ → \ci-gate\ on this PR
- [ ] Confirm release.yml still only triggers after successful CI on main
- [ ] Optional local: \
pm run release:verify\ (needs Playwright browsers)