### PR TITLE
refactor(config): own channel config under src/config with justified root pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
           name: build-output
           path: |
             dist/
-            modules/user-release-notes.generated.js
           if-no-files-found: error
           retention-days: 14
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -100,8 +100,10 @@ PRs only run CI. Merges to `main` run CI once; Release waits for that run and do
 | `dist/billtube-fw.js` | `src/billtube-fw.ts` via esbuild | Loader; derives `BASE` for all assets |
 | `dist/*.bundle.js` (6 files) | `modules/` via esbuild | Feature code |
 | `dist/css/*.css` (8 files) | `src/styles/` via dart-sass | Theme styles |
-| `channel_config_settings.js` | Build copy of `src/config/` (CDN pin applied at release) |
+| `channel_config_settings.js` | Build copy of `src/config/channel_config_settings.js` (authored template with `@__VERSION__`); CDN pin `@vX.Y.Z` applied at release |
 | `src/config/user-release-notes.json` | End-user Recent Updates copy (bundled into admin) |
+
+**Authored vs generated:** Edit only under `src/config/`. The root `channel_config_settings.js` is generated for jsDelivr / CyTube External JS and must stay at repo root so existing CDN URLs keep working (see #211 / `ROOT_OWNERSHIP.md`). Local CyTube testing should use `dev/channel-settings.js` (`npm run dev`), not hand-edited root pins.
 
 `dist/` (including `dist/css/`) and generated modules are **gitignored on `main`** between releases. Release tags include built assets for jsDelivr (`@vX.Y.Z`).
 
@@ -109,9 +111,9 @@ PRs only run CI. Merges to `main` run CI once; Release waits for that run and do
 
 On each releasable push to `main` (after CI passes):
 
-1. **CI** — `npm run lint:ci`, `typecheck`, `test`, `build`, Playwright E2E; upload `dist/`, `user-release-notes.generated.js`
+1. **CI** — `npm run lint:ci`, `typecheck`, `test`, `build`, Playwright E2E; upload `dist/`
 2. **Release** — assert CI jobs (`verify`, `e2e`, `ci-gate`), download artifacts (`SKIP_BUILD=1`), `verify-dist`
-3. **semantic-release** — version bump, changelog, `prepare:release` (skip build, run `inject-cdn-version.js`)
+3. **semantic-release** — version bump, changelog, `prepare:release` (skip build, run `inject-cdn-version.js` which reads `src/config/channel_config_settings.js` and writes the root pin)
 4. **Git commit** — `package.json`, `CHANGELOG.md`, pinned `channel_config_settings.js`, all `dist/*.js`, all `dist/css/*.css`
 5. **Git tag** — `vX.Y.Z`
 6. **Purge** — `npm run purge-cdn` invalidates jsDelivr cache for every shipped path
@@ -128,8 +130,10 @@ npm run release:verify
 
 `scripts/inject-cdn-version.js` runs during `prepare:release` **after** semantic-release bumps `package.json` version:
 
-- Replaces `gh/intentionallyIncomplete/cytube-custom-overlay-theme@*` refs in `channel_config_settings.js` with `@vX.Y.Z`
-- Also supports `@__VERSION__` placeholder if present
+- Reads **authored** `src/config/channel_config_settings.js` (never mutates source)
+- Writes **generated** root `channel_config_settings.js`
+- Replaces `@__VERSION__` and any `gh/...@*` CDN refs with `@vX.Y.Z`
+- Fails if the source is missing the placeholder or the output still contains `@__VERSION__`
 
 The pinned `CDN_BASE` in the release commit must match the git tag viewers load from jsDelivr.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [src/workers/movies-storage/README.md](src/workers/movies-storage/README.md)
 src/
 ├── lib/            # Shared helpers (imported by modules + tests)
 ├── modules/        # BTFW feature modules (bundled into dist/)
-├── config/         # Channel snippet source + user-release-notes.json
+├── config/         # Authored channel snippet + user-release-notes.json
 ├── styles/         # Authored SCSS (source of truth)
 ├── assets/         # Authored branding SVGs (KLIPY, theme icons, monkey paw)
 ├── workers/        # Cloudflare workers (movies-storage, vidprox)
@@ -84,7 +84,7 @@ src/
 dist/               # Built JS bundles + dist/css/ (gitignored on main)
 tests/              # unit/ + e2e/ + fixtures/ + test-results/ (Playwright)
 scripts/            # Build / verify / release tooling
-channel_config_settings.js   # Build output for jsDelivr (gitignored on main)
+channel_config_settings.js   # Generated CyTube/jsDelivr pin (from src/config/; do not hand-edit)
 ```
 
 Root folder ownership (source / generated / tests / tooling), keep/move/merge decisions, and the post-epic target tree are documented in [ROOT_OWNERSHIP.md](ROOT_OWNERSHIP.md) (issue #207 / epic #206).

--- a/ROOT_OWNERSHIP.md
+++ b/ROOT_OWNERSHIP.md
@@ -27,7 +27,7 @@ Guarded by Vitest: `npm run test:vitest`.
 | `dist/` | generated | keep | `dist/` (includes `dist/css/`) | #208 done |
 | `node_modules/` | deps | keep | `node_modules/` | — |
 | `scripts/` | tooling | keep (tighten) | `scripts/` | #212 |
-| `src/` | source | keep | `src/` (styles + assets) | #208/#209 done |
+| `src/` | source | keep | `src/` (styles + assets + config) | #208/#209/#211 done |
 | `tests/` | tests | keep | `tests/` (`unit/` + `e2e/` + `fixtures/` + `test-results/`) | #210 done |
 
 ### Completed relocations
@@ -49,7 +49,6 @@ Leftover root `scss/` / `css/` / `assets/` / `test/` / `e2e/` / `test-results/` 
 |------|---------------|------------|
 | `dev/` | Only exists for local channel snippets | Keep as gitignored local-ephemera |
 | `scripts/` | Mix of shared release tooling and (gitignored) dev helpers | #212: keep shared scripts only |
-| `channel_config_settings.js` (root file) | Generated runtime pin at repo root | #211: ownership behind `src/config/` |
 
 ## Target root layout (after epic #206)
 
@@ -68,11 +67,22 @@ Local-only (gitignored, not part of the public layout contract): `.cursor/`, `de
 
 ## Notable root files (ownership, not directories)
 
-| File | Ownership | Decision | Follow-up |
-|------|-----------|----------|-----------|
-| `channel_config_settings.js` | generated | move ownership / minimize root runtime | #211 |
-| `package.json`, `tsconfig*.json`, `playwright.config.js`, `stylelint.config.js`, `vitest.config.ts` | tooling | keep at root | — |
-| `README.md`, `BUILD.md`, `CHANGELOG.md`, `ROOT_OWNERSHIP.md` | tooling/docs | keep at root (`docs/` is gitignored) | — |
+Encoded as `NOTABLE_ROOT_FILES` in [`scripts/root-ownership.ts`](scripts/root-ownership.ts).
+
+| File | Ownership | Authored? | Decision | Justification |
+|------|-----------|-----------|----------|---------------|
+| `channel_config_settings.js` | generated | **No** — source is `src/config/channel_config_settings.js` | **keep** at root (#211 done) | Required jsDelivr + CyTube External JS URL shape; build copies template (`@__VERSION__`), release pins `@vX.Y.Z` |
+| `package.json`, `tsconfig*.json`, `playwright.config.js`, `stylelint.config.js`, `vitest.config.ts` | tooling | Yes | keep at root | — |
+| `README.md`, `BUILD.md`, `CHANGELOG.md`, `ROOT_OWNERSHIP.md` | tooling/docs | Yes | keep at root (`docs/` is gitignored) | — |
+
+### Authored vs generated (config)
+
+| Path | Role |
+|------|------|
+| `src/config/channel_config_settings.js` | **Authored** CyTube snippet template (`CDN_BASE` uses `@__VERSION__`) |
+| `src/config/user-release-notes.json` | **Authored** Recent Updates copy (bundled into `dist/admin.bundle.js`) |
+| `channel_config_settings.js` (root) | **Generated** runtime pin for operators / CDN (do not hand-edit) |
+| `dev/channel-settings.js` | **Generated** local-only snippet (`npm run dev`); never ships |
 
 ## Acceptance (#207)
 
@@ -81,7 +91,7 @@ Local-only (gitignored, not part of the public layout contract): `.cursor/`, `de
 - [x] Ambiguous one-offs have a proposed destination + owning follow-up issue
 - [x] Target root layout is documented here and encoded in `TARGET_ROOT_LAYOUT`
 
-## Progress (#208 / #209 / #210)
+## Progress (#208 / #209 / #210 / #211)
 
 - [x] Authored styles live under `src/styles/`
 - [x] Generated CSS ships only under `dist/css/`
@@ -90,5 +100,7 @@ Local-only (gitignored, not part of the public layout contract): `.cursor/`, `de
 - [x] Unit + e2e tests live under `tests/` (`unit/`, `e2e/`, `fixtures/`)
 - [x] Playwright artifacts (including `.last-run.json`) live under `tests/test-results/`
 - [x] Playwright / Node / Vitest / CI / docs paths updated for the unified tree
+- [x] Config source lives under `src/config/`; root `channel_config_settings.js` kept with explicit jsDelivr/CyTube justification
+- [x] Build/release pin path is reproducible from source-owned config
 
-Remaining physical moves: #211–#212.
+Remaining physical moves: #212.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,6 +11,11 @@ import {
   isDevBuild,
   MODULE_BUNDLE_BANNER
 } from "./build-options.js";
+import {
+  CHANNEL_CONFIG_ROOT_PATH,
+  CHANNEL_CONFIG_SOURCE_PATH,
+  verifyChannelConfigSource
+} from "../src/lib/channel-config.js";
 
 const buildFlags = {
   js: !process.argv.includes("--css-only"),
@@ -27,21 +32,26 @@ if (!fs.existsSync(distDir)) {
 }
 
 const configDir = path.join(rootDir, "src", "config");
-const channelConfigSrc = path.join(configDir, "channel_config_settings.js");
-const channelConfigOut = path.join(rootDir, "channel_config_settings.js");
+const channelConfigSrc = path.join(rootDir, CHANNEL_CONFIG_SOURCE_PATH);
+const channelConfigOut = path.join(rootDir, CHANNEL_CONFIG_ROOT_PATH);
 
 function copyChannelConfig() {
   if (!fs.existsSync(channelConfigSrc)) {
-    console.warn("⚠ src/config/channel_config_settings.js missing");
-    return;
+    throw new Error(`Missing ${CHANNEL_CONFIG_SOURCE_PATH}`);
   }
   const body = fs.readFileSync(channelConfigSrc, "utf8");
-  const existing = fs.existsSync(channelConfigOut) ? fs.readFileSync(channelConfigOut, "utf8") : null;
+  const sourceCheck = verifyChannelConfigSource(body);
+  if (!sourceCheck.ok) {
+    throw new Error(sourceCheck.reason);
+  }
+  const existing = fs.existsSync(channelConfigOut)
+    ? fs.readFileSync(channelConfigOut, "utf8")
+    : null;
   if (existing === body) {
     return;
   }
   fs.writeFileSync(channelConfigOut, body, "utf8");
-  console.log("✓ Copied channel_config_settings.js");
+  console.log(`✓ Copied ${CHANNEL_CONFIG_ROOT_PATH} from ${CHANNEL_CONFIG_SOURCE_PATH}`);
 }
 
 function generateUserReleaseNotes() {

--- a/scripts/inject-cdn-version.js
+++ b/scripts/inject-cdn-version.js
@@ -1,35 +1,52 @@
+#!/usr/bin/env node
+
 import { readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { execSync } from "child_process";
 
+import {
+  CHANNEL_CONFIG_CDN_REPO,
+  CHANNEL_CONFIG_ROOT_PATH,
+  CHANNEL_CONFIG_SOURCE_PATH,
+  pinChannelConfigContent,
+  verifyChannelConfigSource,
+  verifyPinnedChannelConfig,
+} from "../src/lib/channel-config.js";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.join(__dirname, "..");
-const REPO = "intentionallyIncomplete/cytube-custom-overlay-theme";
-const CONFIG_SRC = path.join(rootDir, "src", "config", "channel_config_settings.js");
-const CONFIG_OUT = path.join(rootDir, "channel_config_settings.js");
+const CONFIG_SRC = path.join(rootDir, CHANNEL_CONFIG_SOURCE_PATH);
+const CONFIG_OUT = path.join(rootDir, CHANNEL_CONFIG_ROOT_PATH);
 const commit = process.argv.includes("--commit");
 
-const version = JSON.parse(readFileSync(path.join(rootDir, "package.json"), "utf8")).version;
+const version = JSON.parse(
+  readFileSync(path.join(rootDir, "package.json"), "utf8")
+).version;
 const tag = `v${version}`;
-const cdnRef = `@${tag}`;
 
-let content = readFileSync(CONFIG_SRC, "utf8");
-const updated = content
-  .replaceAll("@__VERSION__", cdnRef)
-  .replace(
-    new RegExp(`gh/${REPO.replace("/", "\\/")}@[^/"']+`, "g"),
-    `gh/${REPO}@${tag}`
-  );
+const source = readFileSync(CONFIG_SRC, "utf8");
+const sourceCheck = verifyChannelConfigSource(source);
+if (!sourceCheck.ok) {
+  console.error(`✗ ${sourceCheck.reason}`);
+  process.exit(1);
+}
 
-if (content === updated) {
-  console.log(`CDN already pinned to ${tag}`);
-  writeFileSync(CONFIG_OUT, updated, "utf8");
-  process.exit(0);
+const updated = pinChannelConfigContent(source, version, CHANNEL_CONFIG_CDN_REPO);
+const pinCheck = verifyPinnedChannelConfig(updated, tag);
+if (!pinCheck.ok) {
+  console.error(`✗ ${pinCheck.reason}`);
+  process.exit(1);
 }
 
 writeFileSync(CONFIG_OUT, updated, "utf8");
-console.log(`Pinned ${path.relative(rootDir, CONFIG_OUT)} to ${tag} (from src/config)`);
+if (source === updated) {
+  console.log(`CDN already pinned to ${tag}`);
+} else {
+  console.log(
+    `Pinned ${path.relative(rootDir, CONFIG_OUT)} to ${tag} (from ${CHANNEL_CONFIG_SOURCE_PATH})`
+  );
+}
 
 if (!commit) {
   process.exit(0);
@@ -37,7 +54,7 @@ if (!commit) {
 
 execSync('git config user.email "ci@github.com"', { stdio: "inherit" });
 execSync('git config user.name "GitHub Actions"', { stdio: "inherit" });
-execSync("git add channel_config_settings.js", { stdio: "inherit" });
+execSync(`git add ${CHANNEL_CONFIG_ROOT_PATH}`, { stdio: "inherit" });
 try {
   execSync("git diff --cached --quiet");
   console.log("Nothing to commit");
@@ -45,5 +62,7 @@ try {
 } catch {
   // staged changes present
 }
-execSync(`git commit -m "chore: pin CDN to ${tag} [skip ci]"`, { stdio: "inherit" });
+execSync(`git commit -m "chore: pin CDN to ${tag} [skip ci]"`, {
+  stdio: "inherit",
+});
 execSync("git push", { stdio: "inherit" });

--- a/scripts/root-ownership.ts
+++ b/scripts/root-ownership.ts
@@ -126,7 +126,7 @@ export const ROOT_DIRECTORY_CATALOG: readonly RootDirectoryEntry[] = [
     followUpIssue: null,
     purpose: "Application source: boot, modules, lib, config, workers, styles, assets.",
     notes:
-      "Authored styles live under src/styles/ (#208). Authored static assets live under src/assets/ (#209).",
+      "Authored styles live under src/styles/ (#208). Authored static assets live under src/assets/ (#209). Authored channel config + release notes live under src/config/ (#211).",
   },
   {
     path: "tests",
@@ -139,6 +139,82 @@ export const ROOT_DIRECTORY_CATALOG: readonly RootDirectoryEntry[] = [
       "Consolidated from root test/ + e2e/ (#210). Layout: tests/unit/, tests/e2e/, tests/fixtures/, tests/test-results/.",
   },
 ] as const;
+
+/**
+ * Notable root *files* (not directories) with ownership + keep justification.
+ * Complements {@link ROOT_DIRECTORY_CATALOG} for issue #211.
+ */
+export interface NotableRootFileEntry {
+  readonly path: string;
+  readonly ownership: OwnershipLabel;
+  readonly decision: LayoutDecision;
+  /** Authored source path when this file is generated; null when hand-authored at root. */
+  readonly sourcePath: string | null;
+  readonly followUpIssue: number | null;
+  readonly purpose: string;
+  /** Why this root path is allowed (especially for generated runtime). */
+  readonly justification: string;
+}
+
+export const NOTABLE_ROOT_FILES: readonly NotableRootFileEntry[] = [
+  {
+    path: "channel_config_settings.js",
+    ownership: "generated",
+    decision: "keep",
+    sourcePath: "src/config/channel_config_settings.js",
+    followUpIssue: null,
+    purpose:
+      "CyTube External JS / jsDelivr entry that boots BillTube with a pinned CDN_BASE.",
+    justification:
+      "Must stay at repo root so existing operator URLs (cdn.jsdelivr.net/gh/.../@vX.Y.Z/channel_config_settings.js) keep working. Authored only under src/config/; root is emitted by build (unpinned template) and pinned by inject-cdn-version during release.",
+  },
+] as const;
+
+export function findNotableRootFile(
+  path: string
+): NotableRootFileEntry | undefined {
+  return NOTABLE_ROOT_FILES.find((entry) => entry.path === path);
+}
+
+/**
+ * Validates notable-root-file invariants for issue #211.
+ */
+export function validateNotableRootFileInvariants(): string[] {
+  const errors: string[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of NOTABLE_ROOT_FILES) {
+    if (seen.has(entry.path)) {
+      errors.push(`Duplicate notable root file: ${entry.path}`);
+    }
+    seen.add(entry.path);
+
+    if (!isOwnershipLabel(entry.ownership)) {
+      errors.push(`${entry.path}: invalid ownership label`);
+    }
+    if (!isLayoutDecision(entry.decision)) {
+      errors.push(`${entry.path}: invalid layout decision`);
+    }
+    if (entry.purpose.trim().length === 0) {
+      errors.push(`${entry.path}: missing purpose`);
+    }
+    if (entry.justification.trim().length === 0) {
+      errors.push(`${entry.path}: missing justification`);
+    }
+    if (entry.ownership === "generated" && entry.sourcePath === null) {
+      errors.push(`${entry.path}: generated files require a sourcePath`);
+    }
+    if (
+      entry.ownership === "generated" &&
+      entry.sourcePath !== null &&
+      entry.sourcePath.trim().length === 0
+    ) {
+      errors.push(`${entry.path}: sourcePath must not be empty`);
+    }
+  }
+
+  return errors;
+}
 
 const OWNERSHIP_LABELS: readonly OwnershipLabel[] = [
   "source",
@@ -249,6 +325,13 @@ export function validateCatalogInvariants(): string[] {
   }
 
   return errors;
+}
+
+/**
+ * Validates catalog + notable-root-file invariants used by issues #207 / #211.
+ */
+export function validateAllOwnershipInvariants(): string[] {
+  return [...validateCatalogInvariants(), ...validateNotableRootFileInvariants()];
 }
 
 /**

--- a/src/lib/channel-config.js
+++ b/src/lib/channel-config.js
@@ -1,0 +1,83 @@
+/**
+ * Channel config source vs root runtime pin helpers (issue #211).
+ * Source of truth: src/config/channel_config_settings.js
+ * Generated runtime: ./channel_config_settings.js (jsDelivr / CyTube External JS)
+ */
+
+/** @typedef {{ ok: true } | { ok: false, reason: string }} ChannelConfigResult */
+
+export const CHANNEL_CONFIG_SOURCE_PATH = "src/config/channel_config_settings.js";
+export const CHANNEL_CONFIG_ROOT_PATH = "channel_config_settings.js";
+export const CHANNEL_CONFIG_VERSION_PLACEHOLDER = "@__VERSION__";
+export const CHANNEL_CONFIG_CDN_REPO =
+  "intentionallyIncomplete/cytube-custom-overlay-theme";
+
+/**
+ * Source template must keep the release placeholder and must not ship a concrete pin.
+ * @param {string} content
+ * @returns {ChannelConfigResult}
+ */
+export function verifyChannelConfigSource(content) {
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return { ok: false, reason: "channel config source is empty" };
+  }
+  if (/@v\d+\.\d+\.\d+/.test(content)) {
+    return {
+      ok: false,
+      reason: "channel config source must not contain a concrete @vX.Y.Z pin",
+    };
+  }
+  if (!content.includes(CHANNEL_CONFIG_VERSION_PLACEHOLDER)) {
+    return {
+      ok: false,
+      reason: `channel config source missing ${CHANNEL_CONFIG_VERSION_PLACEHOLDER}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Pins CDN refs in channel config content for a release tag.
+ * Never mutates the source file — callers write the result to the root runtime path.
+ * @param {string} content
+ * @param {string} version Semver without leading v (e.g. 1.2.3)
+ * @param {string} [repo]
+ * @returns {string}
+ */
+export function pinChannelConfigContent(
+  content,
+  version,
+  repo = CHANNEL_CONFIG_CDN_REPO
+) {
+  const normalizedVersion = version.replace(/^v/, "");
+  const tag = `v${normalizedVersion}`;
+  const cdnRef = `@${tag}`;
+  const escapedRepo = repo.replace("/", "\\/");
+
+  return content
+    .replaceAll(CHANNEL_CONFIG_VERSION_PLACEHOLDER, cdnRef)
+    .replace(new RegExp(`gh/${escapedRepo}@[^/"']+`, "g"), `gh/${repo}@${tag}`);
+}
+
+/**
+ * @param {string} content
+ * @param {string} tag e.g. v1.2.3
+ * @returns {ChannelConfigResult}
+ */
+export function verifyPinnedChannelConfig(content, tag) {
+  const normalizedTag = tag.replace(/^@/, "").replace(/^v/, "");
+  const needle = `@v${normalizedTag}`;
+  if (!content.includes(needle)) {
+    return {
+      ok: false,
+      reason: `${CHANNEL_CONFIG_ROOT_PATH} missing CDN pin ${needle}`,
+    };
+  }
+  if (content.includes(CHANNEL_CONFIG_VERSION_PLACEHOLDER)) {
+    return {
+      ok: false,
+      reason: `${CHANNEL_CONFIG_ROOT_PATH} still contains ${CHANNEL_CONFIG_VERSION_PLACEHOLDER}`,
+    };
+  }
+  return { ok: true };
+}

--- a/tests/unit/channel-config.vitest.ts
+++ b/tests/unit/channel-config.vitest.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CHANNEL_CONFIG_CDN_REPO,
+  CHANNEL_CONFIG_ROOT_PATH,
+  CHANNEL_CONFIG_SOURCE_PATH,
+  CHANNEL_CONFIG_VERSION_PLACEHOLDER,
+  pinChannelConfigContent,
+  verifyChannelConfigSource,
+  verifyPinnedChannelConfig,
+} from "../../src/lib/channel-config.js";
+import { CDN_ASSET_PATHS } from "../../src/lib/cdn-deploy.js";
+import {
+  findNotableRootFile,
+  validateNotableRootFileInvariants,
+} from "../../scripts/root-ownership";
+
+const REPO_ROOT: string = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("channel config ownership (issue #211)", () => {
+  it("keeps authored source under src/config with the version placeholder", () => {
+    const sourcePath: string = join(REPO_ROOT, CHANNEL_CONFIG_SOURCE_PATH);
+    const content: string = readFileSync(sourcePath, "utf8");
+    const result = verifyChannelConfigSource(content);
+
+    expect(result).toEqual({ ok: true });
+    expect(content).toContain(CHANNEL_CONFIG_VERSION_PLACEHOLDER);
+    expect(content).not.toMatch(/@v\d+\.\d+\.\d+/);
+  });
+
+  it("lists the root pin as the first CDN asset path", () => {
+    expect(CDN_ASSET_PATHS[0]).toBe(CHANNEL_CONFIG_ROOT_PATH);
+  });
+
+  it("pins placeholder content for a release tag without mutating source semantics", () => {
+    const source =
+      `const CDN_BASE = "https://cdn.jsdelivr.net/gh/${CHANNEL_CONFIG_CDN_REPO}${CHANNEL_CONFIG_VERSION_PLACEHOLDER}";\n`;
+    const pinned: string = pinChannelConfigContent(source, "1.2.3");
+
+    expect(pinned).toContain(`@v1.2.3`);
+    expect(pinned).not.toContain(CHANNEL_CONFIG_VERSION_PLACEHOLDER);
+    expect(verifyPinnedChannelConfig(pinned, "v1.2.3")).toEqual({ ok: true });
+    expect(verifyChannelConfigSource(source)).toEqual({ ok: true });
+  });
+
+  it("rewrites an existing gh/@ref pin to the target release tag", () => {
+    const source =
+      `const CDN_BASE = "https://cdn.jsdelivr.net/gh/${CHANNEL_CONFIG_CDN_REPO}@v9.9.9";\n`;
+    const pinned: string = pinChannelConfigContent(source, "v2.0.0");
+
+    expect(pinned).toContain(`gh/${CHANNEL_CONFIG_CDN_REPO}@v2.0.0`);
+    expect(pinned).not.toContain("@v9.9.9");
+  });
+
+  it("rejects source that already contains a concrete release pin", () => {
+    const result = verifyChannelConfigSource(
+      `const CDN_BASE = "https://cdn.jsdelivr.net/gh/${CHANNEL_CONFIG_CDN_REPO}@v1.0.0";\n`
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("concrete");
+    }
+  });
+
+  it("rejects pinned output that still has the placeholder", () => {
+    const result = verifyPinnedChannelConfig(
+      `const CDN_BASE = "...${CHANNEL_CONFIG_VERSION_PLACEHOLDER}";\n`,
+      "v1.2.3"
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("catalogues the root runtime file as generated with a justified keep", () => {
+    expect(validateNotableRootFileInvariants()).toEqual([]);
+    expect(findNotableRootFile(CHANNEL_CONFIG_ROOT_PATH)).toMatchObject({
+      ownership: "generated",
+      decision: "keep",
+      sourcePath: CHANNEL_CONFIG_SOURCE_PATH,
+      followUpIssue: null,
+    });
+    expect(findNotableRootFile(CHANNEL_CONFIG_ROOT_PATH)?.justification).toContain(
+      "jsdelivr"
+    );
+    expect(findNotableRootFile(CHANNEL_CONFIG_ROOT_PATH)?.justification).toContain(
+      "src/config"
+    );
+  });
+});

--- a/tests/unit/root-ownership.vitest.ts
+++ b/tests/unit/root-ownership.vitest.ts
@@ -6,11 +6,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   findCatalogEntry,
+  findNotableRootFile,
   findUnclassifiedDirectories,
   getActionableEntries,
   IGNORED_FOR_LAYOUT_CONTRACT,
   ROOT_DIRECTORY_CATALOG,
   TARGET_ROOT_LAYOUT,
+  validateAllOwnershipInvariants,
   validateCatalogInvariants,
   type LayoutDecision,
   type OwnershipLabel,
@@ -28,6 +30,7 @@ function listRootDirectories(): string[] {
 describe("root ownership catalog (issue #207)", () => {
   it("passes catalog invariants for every entry", () => {
     expect(validateCatalogInvariants()).toEqual([]);
+    expect(validateAllOwnershipInvariants()).toEqual([]);
   });
 
   it("classifies every directory currently present at the repo root", () => {
@@ -61,20 +64,28 @@ describe("root ownership catalog (issue #207)", () => {
     }
   });
 
-  it("maps remaining follow-up work to issues #211–#212", () => {
+  it("maps remaining follow-up work to issue #212", () => {
     const followUps = ROOT_DIRECTORY_CATALOG.filter(
       (entry) => entry.followUpIssue !== null
     );
-    expect(followUps.length).toBeGreaterThan(0);
+    expect(followUps).toHaveLength(1);
+    expect(followUps[0]).toMatchObject({
+      path: "scripts",
+      followUpIssue: 212,
+    });
 
-    for (const entry of followUps) {
-      expect(entry.followUpIssue).toBeGreaterThanOrEqual(211);
-      expect(entry.followUpIssue).toBeLessThanOrEqual(212);
-      expect(entry.destination.length).toBeGreaterThan(0);
-    }
-
-    // #210 merges completed: no move/merge actionable catalog entries remain
+    // #208–#211 directory moves/merges completed
     expect(getActionableEntries()).toEqual([]);
+  });
+
+  it("documents justified root channel_config_settings.js as generated keep", () => {
+    expect(findNotableRootFile("channel_config_settings.js")).toMatchObject({
+      ownership: "generated",
+      decision: "keep",
+      sourcePath: "src/config/channel_config_settings.js",
+      followUpIssue: null,
+    });
+    expect(findCatalogEntry("src")?.notes).toContain("src/config/");
   });
 
   it("keeps src and dist as stable ownership anchors", () => {

--- a/tests/unit/tsconfig.json
+++ b/tests/unit/tsconfig.json
@@ -8,6 +8,7 @@
     "../../scripts/root-ownership.ts",
     "../../src/lib/style-paths.js",
     "../../src/lib/cdn-deploy.js",
+    "../../src/lib/channel-config.js",
     "../../src/lib/asset-paths.ts",
     "../../vitest.config.ts"
   ]

--- a/tsconfig.strict-tools.json
+++ b/tsconfig.strict-tools.json
@@ -18,6 +18,7 @@
     "vitest.config.ts",
     "src/lib/style-paths.js",
     "src/lib/cdn-deploy.js",
+    "src/lib/channel-config.js",
     "src/lib/asset-paths.ts"
   ],
   "exclude": ["dist", "node_modules", "src/workers"]


### PR DESCRIPTION
## Summary
- Confirm config authorship under `src/config/`; keep root `channel_config_settings.js` as the justified jsDelivr/CyTube External JS pin
- Add `src/lib/channel-config.js` helpers; harden `build` + `inject-cdn-version` to fail on missing/invalid source
- Encode notable root files in `scripts/root-ownership.ts` + docs; Vitest coverage for source/pin/ownership
- Fix CI artifact upload to only ship `dist/`

Closes #211

## Test plan
- [x] `npm run test:vitest` (27 pass)
- [x] `npm run typecheck`
- [x] `npm run test:node`
- [x] `node scripts/inject-cdn-version.js` (pins from src without mutating source)